### PR TITLE
ArrowParents -> avoid

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,3 +1,4 @@
 {
-    "semi": false
+    "semi": false,
+    "arrowParens": "avoid"
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@flywheel-jp/prettier-config",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared Prettier config for FLYWHEEL Inc.",
   "main": "index.json",
   "repository": "git@github.com:flywheel-jp/prettier-config.git",
   "license": "MIT",
   "author": "Yuku Takahashi <yuku@flywheel.jp>",
   "peerDependencies": {
-    "prettier": "^1.18.2"
+    "prettier": "^2.0.5"
   }
 }


### PR DESCRIPTION
# What
Default value of `arrowParens` has been changed in prettier 2.0.0 from "avoid" to "always". This change reverts it to use "avoid".

# Refs
- [arrow-function-parentheses](https://prettier.io/docs/en/options.html#arrow-function-parentheses)